### PR TITLE
fixed bug when timezone at end ranges (e.g. -12)

### DIFF
--- a/lib/match_user.js
+++ b/lib/match_user.js
@@ -91,6 +91,17 @@ function timezonesNear(tz) {
     zones.push(11);
   }
 
+ // add in zones >= 12		 +  // if center is -12, add in time zone +11 manually
+ if (zones.indexOf(-12) > -1) {
+   zones.push(12);
+ }
+ if (zones.indexOf(-11) > -1) {
+   zones.push(13);
+ }
+ if (zones.indexOf(-10) > -1) {
+   zones.push(14);
+ }
+
   return zones;
 }
 

--- a/lib/match_user.js
+++ b/lib/match_user.js
@@ -75,26 +75,20 @@ function makeMatch(id1, id2) {
   returns array of timezones that differ from input by <= 1.5 hours
 */
 function timezonesNear(tz) {
-  // tzs MUST MATCH timezone options on input form!!!
-  var tzs = [-12,-11,-10,-9.5,-9,-8,-7,-6,-5,-4,-3.5,-3,-2.5,-2,-1,0,1,2,3,3.5,4,4.5,5,5.5,6,6.5,7,8,9,9.5,10,10.5,11,12,13,14];
+  // tzs MUST MATCH timezone options on input form (up through UTC +11)!!!
+  var tzs = [-12,-11,-10,-9.5,-9,-8,-7,-6,-5,-4,-3.5,-3,-2.5,-2,-1,0,1,2,3,3.5,4,4.5,5,5.5,6,6.5,7,8,9,9.5,10,10.5,11];
 
   // maps 12 -> -12, 13 -> -11, etc.
   var center = ((tz + 12) % 24) - 12;
 
   // catch appropriate slice of tzs
-  var start = tzs.indexOf(Math.floor(center - 1));
+  var start = Math.max(tzs.indexOf(Math.floor(center - 1)), 0);
   var stop = tzs.indexOf(Math.ceil(center + 1)) + 1;
   var zones = tzs.slice(start, stop);
 
-  // add in zones >= 12
-  if (zones.indexOf(-12) > -1) {
-    zones.push(12);
-  }
-  if (zones.indexOf(-11) > -1) {
-    zones.push(13);
-  }
-  if (zones.indexOf(-10) > -1) {
-    zones.push(14);
+  // if center is -12, add in time zone +11 manually
+  if (center === -12) {
+    zones.push(11);
   }
 
   return zones;


### PR DESCRIPTION
Basically, if the timezone value was -12, then `start` was -1, and the "slice" of acceptable timezones was an empty array... because you can't start slicing at index =  -1. 