### PR TITLE
redirecting to dash

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -65,7 +65,7 @@ router.get('/slack/install', function (req, res) {
           }
         })
       }
-      res.redirect('/login')
+      res.redirect('/')
     })
   })
 })


### PR DESCRIPTION
Redirects to dash when installing, if user is not logged in, he will be sent to /login automatically