### PR TITLE
set the cookies to 1hour, the module deletes them automatically

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,9 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   store,
+  cookie: {
+    maxAge: 1000 * 60 * 60 // 1 hour
+  },
 }));
 
 // Point to the passport config file


### PR DESCRIPTION
Cookies don't last more than an hour so the issue of the db getting large in the userSessions collection is no longer an issue